### PR TITLE
Seperated Troop XP between simulation and battle

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -93,6 +93,7 @@ namespace BannerlordTweaks
         public bool TroopExperienceBattleMultiplierEnabled { get; set; } = true;
         [XmlElement]
         public float TroopExperienceBattleMultiplier { get; set; } = 8.0f;
+        [XmlElement]
         public bool TroopExperienceSimulationMultiplierEnabled { get; set; } = false;
         [XmlElement]
         public float TroopExperienceSimulationMultiplier { get; set; } = 1.0f;

--- a/Settings.cs
+++ b/Settings.cs
@@ -90,9 +90,12 @@ namespace BannerlordTweaks
 
         #region Troop experience multiplier
         [XmlElement]
-        public bool TroopExperienceMultiplierEnabled { get; set; } = true;
+        public bool TroopExperienceBattleMultiplierEnabled { get; set; } = true;
         [XmlElement]
-        public float TroopExperienceMultiplier { get; set; } = 1.5f;
+        public float TroopExperienceBattleMultiplier { get; set; } = 8.0f;
+        public bool TroopExperienceSimulationMultiplierEnabled { get; set; } = false;
+        [XmlElement]
+        public float TroopExperienceSimulationMultiplier { get; set; } = 1.0f;
         #endregion
 
         #region Workshop tweaks

--- a/TweakedCombatXpModel.cs
+++ b/TweakedCombatXpModel.cs
@@ -13,9 +13,15 @@ namespace BannerlordTweaks
             {
                 base.GetXpFromHit(attackerTroop, attackedTroop, damage, isFatal, isSimulated, out baseXpAmount);
 
-                if (Settings.Instance.TroopExperienceMultiplierEnabled && !attackerTroop.IsHero)
-                    baseXpAmount = (int)Math.Ceiling((Settings.Instance.TroopExperienceMultiplier * baseXpAmount));
-                //MessageBox.Show($"Attacker: {attackerTroop.Name}\nAttacked: {attackedTroop.Name}\nDefault xp: {baseXpAmount / Settings.Instance.TroopExperienceMultiplier}\nMultiplied xp: {baseXpAmount}\nDamage:{damage}");
+                if (Settings.Instance.TroopExperienceBattleMultiplierEnabled && !attackerTroop.IsHero && !isSimulated)
+                {
+                    baseXpAmount = (int)Math.Ceiling((Settings.Instance.TroopExperienceBattleMultiplier * baseXpAmount));
+                    //MessageBox.Show($"Attacker: {attackerTroop.Name}\nAttacked: {attackedTroop.Name}\nDefault xp: {baseXpAmount / Settings.Instance.TroopExperienceBattleMultiplier}\nMultiplied xp: {baseXpAmount}\nDamage:{damage}");
+                }
+                else if (Settings.Instance.TroopExperienceSimulationMultiplierEnabled && !attackerTroop.IsHero && isSimulated)
+                {
+                    baseXpAmount = (int)Math.Ceiling((Settings.Instance.TroopExperienceSimulationMultiplier * baseXpAmount));
+                }
                 xpAmount = baseXpAmount;
                 //MessageBox.Show($"Attacker: {attackerTroop.Name}\nAttacked: {attackedTroop.Name}\nExp amount: {xpAmount}");
             }


### PR DESCRIPTION
In Native simulation (autocalc) gives 8x as much XP than actual battles. This makes autocalcing vs Looters the best way to train troops, since Looters only wound your troops. Most people feel XP in battles is far too slow. Now players can increase battle Troop XP separately, without changing autocalc XP that affects all AI armies as well.

Adjusted and new XML entries:

`  <!-- Troop experience multiplier -->
  <TroopExperienceBattleMultiplierEnabled>true</TroopExperienceBattleMultiplierEnabled>
  <TroopExperienceBattleMultiplier>8</TroopExperienceBattleMultiplier> <!-- Native value is 1 -->
  <TroopExperienceSimulationMultiplierEnabled>false</TroopExperienceSimulationMultiplierEnabled>
  <TroopExperienceSimulationMultiplier>1</TroopExperienceSimulationMultiplier> <!-- Native value is 1 -->
`