### PR TITLE
Added fix/tweak to apply xp by number of troops and allowed tweaking …

### DIFF
--- a/Patches/MobilePartyDailyTickPatch.cs
+++ b/Patches/MobilePartyDailyTickPatch.cs
@@ -1,0 +1,46 @@
+﻿using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+
+namespace BannerlordTweaks.Patches
+{
+    [HarmonyPatch(typeof(MobileParty), "DailyTick")]
+    public class MobilePartyDailyTickPatch
+    {
+        static bool Prefix(MobileParty __instance)
+        {
+            if (__instance.IsActive && __instance.HasPerk(DefaultPerks.Leadership.CombatTips))
+            {
+                for(int i = 0; i < __instance.MemberRoster.Count; i++)
+                {
+                    TroopRosterElement troopElement = __instance.MemberRoster.GetElementCopyAtIndex(i);
+                    int singleTroopPerksXp = Campaign.Current.Models.PartyTrainingModel.GetTroopPerksXp(DefaultPerks.Leadership.CombatTips);
+                    //We remove one troop as this will be applied once later on running of actual DailyTick.
+                    int totalTroopXp = singleTroopPerksXp * (troopElement.Number - 1);
+                    __instance.Party.MemberRoster.AddXpToTroopAtIndex(totalTroopXp, i);
+
+                }
+            }
+            else if (__instance.IsActive && __instance.HasPerk(DefaultPerks.Leadership.RaiseTheMeek))
+            {
+                for (int i = 0; i < __instance.MemberRoster.Count; i++)
+                {
+                    TroopRosterElement troopElement2 = __instance.MemberRoster.GetElementCopyAtIndex(i);
+                    if (troopElement2.Character.Tier < 4)
+                    {
+                        int singleTroopPerksXp2 = Campaign.Current.Models.PartyTrainingModel.GetTroopPerksXp(DefaultPerks.Leadership.RaiseTheMeek);
+                        //We remove one troop as this will be applied once later on running of actual DailyTick.
+                        int totalTroopXp2 = singleTroopPerksXp2 * (troopElement2.Number - 1);
+                        __instance.Party.MemberRoster.AddXpToTroopAtIndex(totalTroopXp2, i);
+                    }
+
+                }
+            }
+            return true;
+        }
+
+        static bool Prepare()
+        {
+            return Settings.Instance.TroopPerkXpMultipliedByStackEnabled;
+        }
+    }
+}

--- a/Patches/TroopPerksXpPatch.cs
+++ b/Patches/TroopPerksXpPatch.cs
@@ -1,0 +1,28 @@
+﻿using HarmonyLib;
+using TaleWorlds.CampaignSystem.SandBox.GameComponents.Map;
+using TaleWorlds.CampaignSystem;
+
+namespace BannerlordTweaks.Patches
+{
+    [HarmonyPatch(typeof(DefaultPartyTrainingModel), "GetTroopPerksXp")]
+    public class TroopPerksXpPatch
+    {
+        static bool Prefix(PerkObject perk, ref int __result)
+        {
+            if (perk == DefaultPerks.Leadership.CombatTips)
+            {
+                __result = Settings.Instance.TroopPerkCombatTipsAmount;
+            }
+            else if (perk == DefaultPerks.Leadership.RaiseTheMeek)
+            {
+                __result = Settings.Instance.TroopPerkRaiseTheMeekAmount;
+            }
+            return false;
+        }
+
+        static bool Prepare()
+        {
+            return Settings.Instance.TroopPerkXpAmountTweakEnabled;
+        }
+    }
+}

--- a/Settings.cs
+++ b/Settings.cs
@@ -63,9 +63,9 @@ namespace BannerlordTweaks
         [XmlElement]
         public bool TroopPerkXpAmountTweakEnabled { get; set; } = true;
         [XmlElement]
-        public int TroopPerkRaiseTheMeekAmount { get; set; } = 120;
+        public int TroopPerkRaiseTheMeekAmount { get; set; } = 60;
         [XmlElement]
-        public int TroopPerkCombatTipsAmount { get; set; } = 40;
+        public int TroopPerkCombatTipsAmount { get; set; } = 20;
         #endregion
 
         #region Tournament patches

--- a/Settings.cs
+++ b/Settings.cs
@@ -57,7 +57,18 @@ namespace BannerlordTweaks
         public float StewardPartySizeBonus { get; set; } = 0.3f;
         #endregion
 
-        # region Tournament patches
+        #region Perk tweaks
+        [XmlElement]
+        public bool TroopPerkXpMultipliedByStackEnabled { get; set; } = true;
+        [XmlElement]
+        public bool TroopPerkXpAmountTweakEnabled { get; set; } = true;
+        [XmlElement]
+        public int TroopPerkRaiseTheMeekAmount { get; set; } = 120;
+        [XmlElement]
+        public int TroopPerkCombatTipsAmount { get; set; } = 40;
+        #endregion
+
+        #region Tournament patches
         [XmlElement]
         public bool TournamentRenownIncreaseEnabled { get; set; } = true;
         [XmlElement]


### PR DESCRIPTION
In Native, XP from the Leadership XP Perks (Combat Tips, Raise the Meek) only apply to singular stacks, the actual number of troops in that unique type doesn't impact the amount of xp earned
For example:
With Raise the Meek:
1 Empire Recruit: Earns 30xp - 500 to go to level one recruit
100 Empire Recruit: Earns 30xp - 500 to go to level one recruit.

This means the stack size doesn't impact the amount of xp earned at all, unsure if intentional but differs from Warband's training model.

The amount of XP given is also extremely low, a Recruit requires approx. 600 xp to level up.
This means 20 days to level one recruit to a levy. So i've added tweaking of these numbers as well.

Happy to make a seperate mod for this if preferred but I think it matches the objectives of this mod quite closely