### PR TITLE
Enables setting for preventing locked item smelting

### DIFF
--- a/Patches/SmeltingVMPatch.cs
+++ b/Patches/SmeltingVMPatch.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using TaleWorlds.Core;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Craft.Smelting;
+using TaleWorlds.Library;
+using System.Windows.Forms;
+
+namespace BannerlordTweaks.Patches
+{
+    /*
+     * Prevent locked items don't show up in smelting list to stop accidental smelting
+     */
+    [HarmonyPatch(typeof(SmeltingVM), "RefreshList")]
+    public class RefreshListPatch
+    {
+        private static void Postfix(SmeltingVM __instance, ItemRoster ____playerItemRoster)
+        {
+            // This appears to be how the game works out if an item is locked
+            // From TaleWorlds.CampaignSystem.ViewModelCollection.SPInventoryVM.InitializeInventory()
+            IEnumerable<ItemRosterElement> locks = Campaign.Current.GetCampaignBehavior<TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors.IInventoryLockTracker>().GetLocks();
+            ItemRosterElement[] locked_items = (locks != null) ? locks.ToArray<ItemRosterElement>() : null;
+
+            bool isLocked(ItemRosterElement test_item)
+            {
+                return locked_items != null && locked_items.Count(delegate (ItemRosterElement x)
+                {
+                    ItemObject lock_item = x.EquipmentElement.Item;
+                    if (lock_item.StringId == test_item.EquipmentElement.Item.StringId)
+                    {
+                        ItemModifier itemModifier = x.EquipmentElement.ItemModifier;
+                        string a = (itemModifier != null) ? itemModifier.StringId : null;
+                        ItemModifier itemModifier2 = test_item.EquipmentElement.ItemModifier;
+                        return a == ((itemModifier2 != null) ? itemModifier2.StringId : null);
+                    }
+                    return false;
+                }) > 0;
+            }
+            MBBindingList<SmeltingItemVM> filteredList = new MBBindingList<SmeltingItemVM>();
+
+            foreach (SmeltingItemVM sItem in __instance.SmeltableItemList)
+            {
+                if (!____playerItemRoster.Any(rItem =>
+                    sItem.Item == rItem.EquipmentElement.Item && isLocked(rItem)
+                ))
+                {
+                    filteredList.Add(sItem);
+                }
+            }
+
+            __instance.SmeltableItemList = filteredList;
+
+            if (__instance.SmeltableItemList.Count == 0)
+            {
+                __instance.CurrentSelectedItem = null;
+            }
+        }
+        /*
+        static bool Prepare()
+        {
+            return Settings.Instance.PreventSmeltingLockedItems;
+        }*/
+    }
+}

--- a/Patches/SmeltingVMPatch.cs
+++ b/Patches/SmeltingVMPatch.cs
@@ -56,10 +56,10 @@ namespace BannerlordTweaks.Patches
                 __instance.CurrentSelectedItem = null;
             }
         }
-        /*
+
         static bool Prepare()
         {
             return Settings.Instance.PreventSmeltingLockedItems;
-        }*/
+        }
     }
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -41,6 +41,8 @@ namespace BannerlordTweaks
         public bool IgnoreCraftingStamina { get; set; } = false;
         [XmlElement]
         public float CraftingStaminaGainOutsideSettlementMultiplier { get; set; } = 1f;
+        [XmlElement]
+        public bool PreventSmeltingLockedItems { get; set; } = true;
         #endregion
 
         #region Battle reward patches


### PR DESCRIPTION
Adds a tweak that stops items marked as locked from showing up in the smelting list. Adds a setting that controls if the tweak is enabled or not.

With how much spam clicking there is in forging at the moment, it's handy to have a way to stop your locked items from appearing in the smelting list.
