### PR TITLE
Prevents quest characters from counting towards party size morale

### DIFF
--- a/Patches/DefaultPartyMoraleModelPatch.cs
+++ b/Patches/DefaultPartyMoraleModelPatch.cs
@@ -1,5 +1,7 @@
-﻿using HarmonyLib;
+﻿using BannerlordTweaks.Lib;
+using HarmonyLib;
 using System;
+using System.Windows.Forms;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.SandBox.GameComponents.Party;
 using TaleWorlds.Core;
@@ -8,27 +10,53 @@ using TaleWorlds.Localization;
 
 namespace BannerlordTweaks.Patches
 {
-    [HarmonyPatch(typeof(DefaultPartyMoraleModel), "GetPartySizeMoraleEffect")]
-    public class GetPartySizeMoraleEffectPatch
+    static public class QuestPartySizeHelper
     {
-        static bool Prefix(GetPartySizeMoraleEffectPatch __instance, MobileParty party, ref ExplainedNumber result, TextObject ____partySizeMoraleText)
+        static public int GetPartySize(MobileParty party)
         {
             int party_size = party.Party.NumberOfAllMembers;
 
             foreach (TroopRosterElement troopRosterElement in party.MemberRoster)
             {
-                if (troopRosterElement.Character == MBObjectManager.Instance.GetObject<CharacterObject>("borrowed_troop") ||
+                if (
+                    (troopRosterElement.Character.Culture.Villager != null &&
+                    troopRosterElement.Character == MBObjectManager.Instance.GetObject<CharacterObject>(troopRosterElement.Character.Culture.Villager.StringId)) ||
+                    troopRosterElement.Character == MBObjectManager.Instance.GetObject<CharacterObject>("borrowed_troop") ||
                     troopRosterElement.Character == MBObjectManager.Instance.GetObject<CharacterObject>("veteran_borrowed_troop"))
                 {
                     party_size -= troopRosterElement.Number;
                 }
             }
-            
-            int num = party_size - party.Party.PartySizeLimit;
+
+            return party_size;
+        }
+    }
+    [HarmonyPatch(typeof(DefaultPartyMoraleModel), "GetPartySizeMoraleEffect")]
+    public class GetPartySizeMoraleEffectPatch
+    {
+        static bool Prefix(MobileParty party, ref ExplainedNumber result, TextObject ____partySizeMoraleText)
+        {
+            int num = QuestPartySizeHelper.GetPartySize(party) - party.Party.PartySizeLimit;
             if (num > 0)
             {
                 result.Add(-1f * (float)Math.Sqrt((double)num), ____partySizeMoraleText);
             }
+            return false;
+        }
+
+        static bool Prepare()
+        {
+            return Settings.Instance.QuestCharactersIgnorePartySize;
+        }
+    }
+
+    [HarmonyPatch(typeof(DefaultPartyMoraleModel), "NumberOfDesertersDueToPaymentRatio")]
+    public class NumberOfDesertersDueToPaymentRatioPatch
+    {
+        static bool Prefix(MobileParty mobileParty, ref int __result)
+        {
+            int partySizeLimit = mobileParty.Party.PartySizeLimit;
+            __result = MBRandom.RoundRandomized(((float)QuestPartySizeHelper.GetPartySize(mobileParty) - mobileParty.PaymentRatio * (float)partySizeLimit) * 0.2f);
             return false;
         }
 

--- a/Patches/DefaultPartyMoraleModelPatch.cs
+++ b/Patches/DefaultPartyMoraleModelPatch.cs
@@ -1,0 +1,42 @@
+﻿using HarmonyLib;
+using System;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.SandBox.GameComponents.Party;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+
+namespace BannerlordTweaks.Patches
+{
+    [HarmonyPatch(typeof(DefaultPartyMoraleModel), "GetPartySizeMoraleEffect")]
+    public class GetPartySizeMoraleEffectPatch
+    {
+        static bool Prefix(GetPartySizeMoraleEffectPatch __instance, MobileParty party, ref ExplainedNumber result, TextObject ____partySizeMoraleText)
+        {
+            int party_size = party.Party.NumberOfAllMembers;
+
+            foreach (TroopRosterElement troopRosterElement in party.MemberRoster)
+            {
+                if (troopRosterElement.Character == MBObjectManager.Instance.GetObject<CharacterObject>("borrowed_troop") ||
+                    troopRosterElement.Character == MBObjectManager.Instance.GetObject<CharacterObject>("veteran_borrowed_troop"))
+                {
+                    party_size -= troopRosterElement.Number;
+                    InformationManager.DisplayMessage(new InformationMessage("Found "+ troopRosterElement.Number + " borrowed troops", Color.FromUint(4282569842U)));
+
+                }
+            }
+            
+            int num = party_size - party.Party.PartySizeLimit;
+            if (num > 0)
+            {
+                result.Add(-1f * (float)Math.Sqrt((double)num), ____partySizeMoraleText);
+            }
+            return false;
+        }
+
+        static bool Prepare()
+        {
+            return Settings.Instance.QuestCharactersIgnorePartySize;
+        }
+    }
+}

--- a/Patches/DefaultPartyMoraleModelPatch.cs
+++ b/Patches/DefaultPartyMoraleModelPatch.cs
@@ -21,8 +21,6 @@ namespace BannerlordTweaks.Patches
                     troopRosterElement.Character == MBObjectManager.Instance.GetObject<CharacterObject>("veteran_borrowed_troop"))
                 {
                     party_size -= troopRosterElement.Number;
-                    InformationManager.DisplayMessage(new InformationMessage("Found "+ troopRosterElement.Number + " borrowed troops", Color.FromUint(4282569842U)));
-
                 }
             }
             

--- a/Settings.cs
+++ b/Settings.cs
@@ -59,6 +59,8 @@ namespace BannerlordTweaks
         public bool StewardPartySizeBonusEnabled { get; set; } = true;
         [XmlElement]
         public float StewardPartySizeBonus { get; set; } = 0.3f;
+        [XmlElement]
+        public bool QuestCharactersIgnorePartySize { get; set; } = true;
         #endregion
 
         # region Tournament patches


### PR DESCRIPTION
Removes quest troops (from the "Landlord Training" quest) from counting towards party morale calculation, so that accepting the quest won't cause your own troops to desert.

Only affects morale calculation, so your party is still listed as being oversized, but prevents the desertions from happening.