### PR TITLE
Automatically Learn New Smelting Parts

### DIFF
--- a/Patches/CraftingCampaignBehaviourPatches.cs
+++ b/Patches/CraftingCampaignBehaviourPatches.cs
@@ -12,17 +12,28 @@ using TaleWorlds.Library;
 
 namespace BannerlordTweaks.Patches
 {
+    public static class SmeltingHelper
+    {
+        public static IEnumerable<CraftingPiece> GetNewPartsFromSmelting(ItemObject item)
+        {
+            return item.WeaponDesign.UsedPieces.Select(
+                    x => x.CraftingPiece
+                ).Where(
+                    x => x != null &&
+                    x.IsValid &&
+                    !Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>().IsOpened(x)
+                );
+        }
+    }
+
     [HarmonyPatch(typeof(CraftingCampaignBehavior), "DoSmelting")]
     public class DoSmeltingPatch
     {
-        private static void Postfix(CraftingCampaignBehavior __instance, Hero hero, ItemObject item, List<CraftingPiece> ____openedParts)
+        private static void Postfix(CraftingCampaignBehavior __instance, ItemObject item)
         {
-            foreach (CraftingPiece piece in item.WeaponDesign.UsedPieces.Select(x => x.CraftingPiece))
+            foreach (CraftingPiece piece in SmeltingHelper.GetNewPartsFromSmelting(item))
             {
-                if (piece != null && piece.IsValid && !__instance.IsOpened(piece))
-                {
-                    typeof(CraftingCampaignBehavior).GetMethod("OpenPart", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(__instance, new object[] { piece });
-                }
+                typeof(CraftingCampaignBehavior).GetMethod("OpenPart", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(__instance, new object[] { piece });
             }
         }
 

--- a/Patches/CraftingCampaignBehaviourPatches.cs
+++ b/Patches/CraftingCampaignBehaviourPatches.cs
@@ -1,12 +1,37 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Windows.Forms;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
 
 namespace BannerlordTweaks.Patches
 {
+    [HarmonyPatch(typeof(CraftingCampaignBehavior), "DoSmelting")]
+    public class DoSmeltingPatch
+    {
+        private static void Postfix(CraftingCampaignBehavior __instance, Hero hero, ItemObject item, List<CraftingPiece> ____openedParts)
+        {
+            foreach (CraftingPiece piece in item.WeaponDesign.UsedPieces.Select(x => x.CraftingPiece))
+            {
+                if (piece != null && piece.IsValid && !__instance.IsOpened(piece))
+                {
+                    typeof(CraftingCampaignBehavior).GetMethod("OpenPart", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(__instance, new object[] { piece });
+                }
+            }
+        }
+
+        static bool Prepare()
+        {
+            return Settings.Instance.AutoLearnSmeltedParts;
+        }
+    }
+
     [HarmonyPatch(typeof(CraftingCampaignBehavior), "GetMaxHeroCraftingStamina")]
     public class GetMaxHeroCraftingStaminaPatch
     {

--- a/Patches/SmeltingVMPatch.cs
+++ b/Patches/SmeltingVMPatch.cs
@@ -6,11 +6,12 @@ using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.ViewModelCollection.Craft.Smelting;
 using TaleWorlds.Library;
 using System.Windows.Forms;
+using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors;
 
 namespace BannerlordTweaks.Patches
 {
     /*
-     * Prevent locked items don't show up in smelting list to stop accidental smelting
+     * Prevent locked items from showing up in smelting list to stop accidental smelting
      */
     [HarmonyPatch(typeof(SmeltingVM), "RefreshList")]
     public class RefreshListPatch
@@ -60,6 +61,29 @@ namespace BannerlordTweaks.Patches
         static bool Prepare()
         {
             return Settings.Instance.PreventSmeltingLockedItems;
+        }
+    }
+
+    [HarmonyPatch(typeof(SmeltingVM), "RefreshList")]
+    [HarmonyPriority(Priority.VeryLow)]
+    public class RefreshList_RenamePatch
+    {
+        private static void Postfix(SmeltingVM __instance, ItemRoster ____playerItemRoster)
+        {
+            foreach(SmeltingItemVM item in __instance.SmeltableItemList)
+            {
+                int count = SmeltingHelper.GetNewPartsFromSmelting(item.Item).Count();
+                if(count > 0)
+                {
+                    string parts = count == 1 ? "part" : "parts";
+                    item.Name = item.Name + $" ({count} new {parts})";
+                }
+            }
+        }
+
+        static bool Prepare()
+        {
+            return Settings.Instance.AutoLearnSmeltedParts;
         }
     }
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -55,10 +55,18 @@ namespace BannerlordTweaks
         [SettingProperty("Crafting Stamina Gain Outside Settlement Multiplier", 0f, 1f, "Native value is 0.0. In native, you do not gain crafting stamina if you are not resting inside a settlement.")]
         [SettingPropertyGroup("Crafting Stamina Tweaks")]
         public float CraftingStaminaGainOutsideSettlementMultiplier { get; set; } = 1f;
+        #endregion
+
+        #region Smelting patches
         [XmlElement]
-        [SettingProperty("Prevent Smelting Locked Items", "Native value is false. Prevent locked items don't show up in smelting list to stop accidental smelting.")]
-        [SettingPropertyGroup("Crafting Stamina Tweaks")]
+        [SettingProperty("Prevent Smelting Locked Items", "Native value is false. Prevent locked items from showing up in smelting list to stop accidental smelting.")]
+        [SettingPropertyGroup("Smelting Tweaks")]
         public bool PreventSmeltingLockedItems { get; set; } = true;
+
+        [XmlElement]
+        [SettingProperty("Learn Smelted Parts", "Native value is false. Automatically acquire the parts of smelted items.")]
+        [SettingPropertyGroup("Smelting Tweaks")]
+        public bool AutoLearnSmeltedParts { get; set; } = true;
         #endregion
 
         #region Battle reward patches


### PR DESCRIPTION
When smelting items that have parts you haven't unlocked, you automatically unlock them. Adds text to the names of these items in the smelting window to indicate how many new parts you unlock.

Hopefully this is a nice way to get rid of some of the smelting grind without just making unlocks much faster. It also means if you have a weapon you like you can smelt it down to gain the ability to produce more of them. I suspect it will mean you unlock the low tier upgrades very quickly (and therefore hopefully progress to the later tiers faster too).