### PR TITLE
Prevents war declarations on yourself, fixing a quest-related crash

### DIFF
--- a/Patches/FactionManagerPatch.cs
+++ b/Patches/FactionManagerPatch.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+
+namespace BannerlordTweaks.Patches
+{
+    [HarmonyPatch(typeof(FactionManager), "RegisterCampaignWar")]
+    class RegisterCampaignWarPatch
+    {
+        public static bool Prefix(IFaction faction1, IFaction faction2)
+        {
+            return faction1.StringId != faction2.StringId;
+        }
+
+        public static bool Prepare()
+        {
+            return Settings.Instance.FixNoDeclareWarOnSelf;
+        }
+    }
+}

--- a/Settings.cs
+++ b/Settings.cs
@@ -406,5 +406,12 @@ namespace BannerlordTweaks
         public float ClanPartiesBonusPerClanTier { get; set; } = 0.5f;
         #endregion
 
+        #region
+        [XmlElement]
+        [SettingProperty("Prevent declaring war on self", "Prevents a crash in native Bannerlord caused by a quest forcing you to declare war on yourself.")]
+        [SettingPropertyGroup("Crash Fixes")]
+        public bool FixNoDeclareWarOnSelf { get; set; } = true;
+        #endregion
+
     }
 }


### PR DESCRIPTION
Fixes Mod Nexus bug "Crash after defeating a faction (Imperial)". Causes war declarations to be ignored if they are declaring war on yourself.

The main quest causes factions to declare war on you at some point; if you were one of the strongest kingdoms, it would improperly select your own kingdom to declare war, causing a crash in the war declaration code. This fix acts to prevent the crash but doesn't attempt to fix the quest behaviour.

(FactionManagerPatch.cs will need to be added to the csproj)