### PR TITLE
Attribute Focus Point Settings

### DIFF
--- a/Patches/DefaultCharacterDevelopmentModelPatch.cs
+++ b/Patches/DefaultCharacterDevelopmentModelPatch.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.SandBox.GameComponents;
+
+namespace BannerlordTweaks.Patches
+{
+    [HarmonyPatch(typeof(DefaultCharacterDevelopmentModel), "get_LevelsPerAttributePoint")]
+    public class DefaultCharacterDevelopmentAttributePatch
+    {
+        private static void Postfix(ref int __result)
+        {
+            __result = Settings.Instance.AttributePointRequiredLevel;
+        }
+
+        static bool Prepare()
+        {
+            return Settings.Instance.AttributeFocusPointTweakEnabled;
+        }
+    }
+
+    [HarmonyPatch(typeof(DefaultCharacterDevelopmentModel), "get_FocusPointsPerLevel")]
+    public class DefaultCharacterDevelopmentFocusPatch
+    {
+        private static void Postfix(ref int __result)
+        {            
+            __result = Settings.Instance.FocusPointsPerLevel;
+        }
+
+        static bool Prepare()
+        {
+            return Settings.Instance.AttributeFocusPointTweakEnabled;
+        }
+    }
+}

--- a/Settings.cs
+++ b/Settings.cs
@@ -418,5 +418,21 @@ namespace BannerlordTweaks
         public float ClanPartiesBonusPerClanTier { get; set; } = 0.5f;
         #endregion
 
+        #region Attribute Focus Point Tweaks
+        [XmlElement]
+        [SettingProperty("Enable Attribute-Focus Point Tweaks", "Changes the values used to calculate how many Attribute and Focus points player gain.")]
+        [SettingPropertyGroup("Attribute-Focus Points Tweaks", true)]
+        public bool AttributeFocusPointTweakEnabled { get; set; } = true;
+
+        [XmlElement]
+        [SettingProperty("Required Level For Attribute Point", 1, 5, "Native value is 4. This is the required level to gain an attribute point")]
+        [SettingPropertyGroup("Attribute-Focus Points Tweaks")]
+        public int AttributePointRequiredLevel { get; set; } = 4;
+
+        [XmlElement]
+        [SettingProperty("Focus Point Per Level", 1, 5, "Native value is 1. This is the amount of focus points earned per level.")]
+        [SettingPropertyGroup("Attribute-Focus Points Tweaks")]
+        public int FocusPointsPerLevel { get; set; } = 1;
+        #endregion
     }
 }


### PR DESCRIPTION
Well[ this mod](https://www.nexusmods.com/mountandblade2bannerlord/mods/121) I did really has high downloads. Seems like people really dont like getting an attribute point every 4 level. I thought adding this option to Bannerlord Tweaks would be best considering the 16 submodule limit for players. 

Added two settings that change the amount of attribute and focus points gained.

![Mount   Blade II  Bannerlord Screenshot 2020 04 11 - 16 11 42 93](https://user-images.githubusercontent.com/18725050/79045013-7eb06880-7c11-11ea-8342-f67719f081e8.png)
