### PR TITLE
battle reward tweaks, influence reward option

### DIFF
--- a/Patches/DefaultBattleRewardModelPatch.cs
+++ b/Patches/DefaultBattleRewardModelPatch.cs
@@ -16,7 +16,7 @@ namespace BannerlordTweaks.Patches
             try
             {
                 ExplainedNumber stat;
-                if (party.LeaderHero != null && party.LeaderHero == Hero.MainHero)
+                if (Settings.Instance.BattleRewardApplyToAI || (party.LeaderHero != null && party.LeaderHero == Hero.MainHero))
                     stat = new ExplainedNumber((renownValueOfBattle * contributionShare) * Settings.Instance.BattleRenownMultiplier, explanation);
                 else
                     stat = new ExplainedNumber(renownValueOfBattle * contributionShare, explanation);
@@ -56,7 +56,7 @@ namespace BannerlordTweaks.Patches
             try
             {
                 ExplainedNumber stat;
-                if (party != null)
+                if (Settings.Instance.BattleRewardApplyToAI || (party.LeaderHero != null && party.LeaderHero == Hero.MainHero))
                     stat = new ExplainedNumber(party.MapFaction.IsKingdomFaction ? (influenceValueOfBattle * contributionShare * Settings.Instance.BattleInfluenceMultiplier) : 0f, explanation, null);
                 else
                     stat = new ExplainedNumber(party.MapFaction.IsKingdomFaction ? (influenceValueOfBattle * contributionShare) : 0f, explanation, null);

--- a/Patches/DefaultBattleRewardModelPatch.cs
+++ b/Patches/DefaultBattleRewardModelPatch.cs
@@ -36,14 +36,45 @@ namespace BannerlordTweaks.Patches
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"An error occurred during DefaultBattleRewardModelPatch. Reverting to original behaviour...\n\nException:\n{ex.Message}\n\n{ex.InnerException?.Message}\n\n{ex.InnerException?.InnerException?.Message}");
+                MessageBox.Show($"An error occurred during DefaultBattleRewardModelRenownPatch. Reverting to original behaviour...\n\nException:\n{ex.Message}\n\n{ex.InnerException?.Message}\n\n{ex.InnerException?.InnerException?.Message}");
             }
             return !patched;
         }
 
         static bool Prepare()
         {
-            return Settings.Instance.BattleRenownMultiplierEnabled;
+            return Settings.Instance.BattleRewardTweaksEnabled;
+        }
+    }
+
+    [HarmonyPatch(typeof(DefaultBattleRewardModel), "CalculateInfluenceGain")]
+    public class DefaultBattleRewardModelInfluencePatch
+    {
+        static bool Prefix(PartyBase party, float influenceValueOfBattle, float contributionShare, StatExplainer explanation, ref float __result)
+        {
+            bool patched = false;
+            try
+            {
+                ExplainedNumber stat;
+                if (party != null)
+                    stat = new ExplainedNumber(party.MapFaction.IsKingdomFaction ? (influenceValueOfBattle * contributionShare * Settings.Instance.BattleInfluenceMultiplier) : 0f, explanation, null);
+                else
+                    stat = new ExplainedNumber(party.MapFaction.IsKingdomFaction ? (influenceValueOfBattle * contributionShare) : 0f, explanation, null);
+
+                __result = stat.ResultNumber;
+                patched = true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"An error occurred during DefaultBattleRewardModelInfluencePatch. Reverting to original behavior... \n\nException:\n{ex.Message}\n\n{ex.InnerException?.Message}\n\n{ex.InnerException?.Message}");
+            }
+
+            return !patched;
+        }
+
+        static bool Prepare()
+        {
+            return Settings.Instance.BattleRewardTweaksEnabled;
         }
     }
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -89,12 +89,19 @@ namespace BannerlordTweaks
         [XmlElement]
         [SettingProperty("Battle Renown Multiplier", 1f, 5f, "Native value is 1.0. The amount of renown you receive from a battle is multiplied by this value.")]
         [SettingPropertyGroup("Battle Reward Tweaks")]
-        public float BattleRenownMultiplier { get; set; } = 2f;
+        public float BattleRenownMultiplier { get; set; } = 1f;
 
         [XmlElement]
         [SettingProperty("Battle Influence Multiplier", 1f, 5f, "Native value is 1.0. The amount of influence you receive from a battle is multiplied by this value.")]
         [SettingPropertyGroup("Battle Reward Tweaks")]
-        public float BattleInfluenceMultiplier { get; set; } = 2f;
+        public float BattleInfluenceMultiplier { get; set; } = 1f;
+
+        [XmlElement]
+        [SettingProperty("Apply To AI", 1f, 5f, "Applies the same multipliers to AI parties.")]
+        [SettingPropertyGroup("Battle Reward Tweaks")]
+        public bool BattleRewardApplyToAI { get; set; } = true;
+
+
         #endregion
 
         #region Party size patches

--- a/Settings.cs
+++ b/Settings.cs
@@ -87,17 +87,17 @@ namespace BannerlordTweaks
         public bool BattleRewardTweaksEnabled { get; set; } = true;
 
         [XmlElement]
-        [SettingProperty("Battle Renown Multiplier", 1f, 5f, "Native value is 1.0. The amount of renown you receive from a battle is multiplied by this value.")]
+        [SettingProperty("Battle Renown Multiplier", 0.1f, 5f, "Native value is 1.0. The amount of renown you receive from a battle is multiplied by this value.")]
         [SettingPropertyGroup("Battle Reward Tweaks")]
         public float BattleRenownMultiplier { get; set; } = 1f;
 
         [XmlElement]
-        [SettingProperty("Battle Influence Multiplier", 1f, 5f, "Native value is 1.0. The amount of influence you receive from a battle is multiplied by this value.")]
+        [SettingProperty("Battle Influence Multiplier", 0.1f, 5f, "Native value is 1.0. The amount of influence you receive from a battle is multiplied by this value.")]
         [SettingPropertyGroup("Battle Reward Tweaks")]
         public float BattleInfluenceMultiplier { get; set; } = 1f;
 
         [XmlElement]
-        [SettingProperty("Apply To AI", 1f, 5f, "Applies the same multipliers to AI parties.")]
+        [SettingProperty("Apply To AI", "Applies the same multipliers to AI parties.")]
         [SettingPropertyGroup("Battle Reward Tweaks")]
         public bool BattleRewardApplyToAI { get; set; } = true;
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -82,13 +82,19 @@ namespace BannerlordTweaks
 
         #region Battle reward patches
         [XmlElement]
-        [SettingProperty("Battle Renown Tweak", "Applies the set multiplier to renown gain from battles (applies to the player only).")]
-        [SettingPropertyGroup("Battle Renown Tweak", true)]
-        public bool BattleRenownMultiplierEnabled { get; set; } = true;
+        [SettingProperty("Battle Reward Tweaks", "Applies the set multiplier to renown and influence gain from battles (applies to the player only).")]
+        [SettingPropertyGroup("Battle Reward Tweaks", true)]
+        public bool BattleRewardTweaksEnabled { get; set; } = true;
+
         [XmlElement]
         [SettingProperty("Battle Renown Multiplier", 1f, 5f, "Native value is 1.0. The amount of renown you receive from a battle is multiplied by this value.")]
-        [SettingPropertyGroup("Battle Renown Tweak")]
+        [SettingPropertyGroup("Battle Reward Tweaks")]
         public float BattleRenownMultiplier { get; set; } = 2f;
+
+        [XmlElement]
+        [SettingProperty("Battle Influence Multiplier", 1f, 5f, "Native value is 1.0. The amount of influence you receive from a battle is multiplied by this value.")]
+        [SettingPropertyGroup("Battle Reward Tweaks")]
+        public float BattleInfluenceMultiplier { get; set; } = 2f;
         #endregion
 
         #region Party size patches


### PR DESCRIPTION
summary:
-added a new option that changes the amount of influence gained from battles
-added a new option that applies the same battle reward multipliers to AI parties
-changed the minimum multiplier values from 1 to 0.1. so if players want they now will be able to lower the amount of influence and renown they gain.

![Mount   Blade II  Bannerlord Screenshot 2020 04 11 - 19 39 19 24](https://user-images.githubusercontent.com/18725050/79049412-38b4ce00-7c2c-11ea-81e0-655e61d588c7.png)
