### PR TITLE
add ability to tweak pregnancy settings

### DIFF
--- a/BannerlordTweaks.csproj
+++ b/BannerlordTweaks.csproj
@@ -122,6 +122,7 @@
     <Compile Include="TweakedSettlementFoodModel.cs" />
     <Compile Include="TweakedSettlementMilitiaModel.cs" />
     <Compile Include="TweakedSiegeEventModel.cs" />
+    <Compile Include="TweakedPregnancyModel.cs" />
     <Compile Include="TweakedWorkshopModel.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Settings.cs
+++ b/Settings.cs
@@ -398,5 +398,39 @@ namespace BannerlordTweaks
         public float ClanPartiesBonusPerClanTier { get; set; } = 0.5f;
         #endregion
 
+		#region Pregnancy tweak
+        [XmlElement]
+        [SettingProperty("Enable No Stillbirths Tweak", "Disables stillbirths")]
+        [SettingPropertyGroup("Pregnancy Tweaks")]
+        public bool NoStillbirthsTweakEnabled { get; set; } = true;
+        [XmlElement]
+        [SettingProperty("Enable No Maternal Mortality Tweak", "Disables maternal mortality")]
+        [SettingPropertyGroup("Pregnancy Tweaks")]
+        public bool NoMaternalMortalityTweakEnabled { get; set; } = true;
+        [XmlElement]
+        [SettingProperty("Enable Pregnancy Duration Tweak", "Allows for adjusting the duration for a pregnancy")]
+        [SettingPropertyGroup("Pregnancy Tweaks")]
+        public bool PregnancyDurationTweakEnabled { get; set; } = false;
+        [XmlElement]
+        [SettingProperty("Pregnancy Duration", 1, 96, "Native value is 36 days.")]
+        [SettingPropertyGroup("Pregnancy Tweaks")]
+        public int PregnancyDuration { get; set; } = 36;
+        [XmlElement]
+        [SettingProperty("Enable Gender Ratio Tweak", "Allows for adjusting the gender ratio of births")]
+        [SettingPropertyGroup("Pregnancy Tweaks")]
+        public bool FemaleOffspringProbabilityTweakEnabled { get; set; } = false;
+        [XmlElement]
+        [SettingProperty("Probability for female children", -1.0f, 1.0f, "Native value is 0.51. Set to -1 to disable female births")]
+        [SettingPropertyGroup("Pregnancy Tweaks")]
+        public float FemaleOffspringProbability { get; set; } = 0.51f;
+        [XmlElement]
+        [SettingProperty("Enable Twins Probability Tweak", "Allows for adjusting the chance of giving birth to twins")]
+        [SettingPropertyGroup("Pregnancy Tweaks")]
+        public bool TwinsProbabilityTweakEnabled { get; set; } = false;
+        [XmlElement]
+        [SettingProperty("Probability to deliver twins", -1.0f, 1.0f, "Native value is 0.03. Determines the chance of giving birth to twins")]
+        [SettingPropertyGroup("Pregnancy Tweaks")]
+        public float TwinsProbability { get; set; } = 0.03f;
+        #endregion
     }
 }

--- a/SubModule.cs
+++ b/SubModule.cs
@@ -72,6 +72,10 @@ namespace BannerlordTweaks
                     gameStarter.AddModel(new TweakedSettlementFoodModel());
                 if (Settings.Instance.SiegeCasualtiesTweakEnabled || Settings.Instance.SiegeConstructionProgressPerDayMultiplierEnabled)
                     gameStarter.AddModel(new TweakedSiegeEventModel());
+                if (Settings.Instance.NoStillbirthsTweakEnabled || Settings.Instance.NoMaternalMortalityTweakEnabled ||
+                    Settings.Instance.PregnancyDurationTweakEnabled || Settings.Instance.FemaleOffspringProbabilityTweakEnabled ||
+                    Settings.Instance.TwinsProbabilityTweakEnabled)
+                    gameStarter.AddModel(new TweakedPregnancyModel());
             }
         }
     }

--- a/TweakedPregnancyModel.cs
+++ b/TweakedPregnancyModel.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.SandBox.GameComponents;
+
+namespace BannerlordTweaks
+{
+    /// <summary>
+    /// Allows for tweaking of the pregnancy Model
+    /// NOTE: we set the probabilities for disabling to -1 since TW does a smaller-equals check on a range of [0,1)
+    /// </summary>
+    public class TweakedPregnancyModel : DefaultPregnancyModel
+    {
+        public override float StillbirthProbability => Settings.Instance.NoStillbirthsTweakEnabled 
+            ? -1 
+            : base.StillbirthProbability;
+
+        public override float MaternalMortalityProbabilityInLabor => Settings.Instance.NoMaternalMortalityTweakEnabled
+            ? -1
+            : base.MaternalMortalityProbabilityInLabor;
+
+        public override float DeliveringTwinsProbability => Settings.Instance.TwinsProbabilityTweakEnabled
+            ? Settings.Instance.TwinsProbability
+            : base.DeliveringTwinsProbability;
+
+        public override float DeliveringFemaleOffspringProbability => Settings.Instance.FemaleOffspringProbabilityTweakEnabled
+            ? Settings.Instance.FemaleOffspringProbability
+            : base.DeliveringFemaleOffspringProbability;
+
+        public override float PregnancyDurationInDays => Settings.Instance.PregnancyDurationTweakEnabled
+            ? Settings.Instance.PregnancyDuration
+            : base.PregnancyDurationInDays;
+    }
+}


### PR DESCRIPTION
the default disables stillbirths and maternal deaths

options include:
stillbirth, maternal deaths
duration of pregnancy
gender ratio for births
twin probability,

@mipen let me know if you want me to keep the native defaults?